### PR TITLE
fix: crashing YouTube player issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -2540,6 +2540,7 @@ async function createYoutubePlayer() {
         console.log('Error destroying player:', e);
       }
       player = null;
+      youtubePlayer = null;
     }
 
     const existingContainer = document.querySelector(
@@ -2590,9 +2591,12 @@ async function createYoutubePlayer() {
         onError: onPlayerError,
       },
     });
+    // Keep legacy handle in sync with the active player instance.
+    youtubePlayer = player;
   } catch (error) {
     console.error('Error initializing YouTube player:', error);
     updatePlaylistBadge('');
+    youtubePlayer = null;
   }
 }
 


### PR DESCRIPTION
From the Cursor agent:

What I found (and fixed)
Your suspicion is well-founded: a real “tab crashed” page is usually renderer/GPU process death, and YouTube iframes are a common trigger on TVs/tablets.

In this codebase there was an “obvious” bug that increases the chance of that happening:

The real YouTube player instance was stored in player, but most stop/pause/destroy logic used youtubePlayer
youtubePlayer was never assigned, so a bunch of “stop/pause/destroy” calls were silently doing nothing → music/video decoding could keep running when the app thought it had stopped. I made the smallest fix: keep youtubePlayer in sync with the real player instance inside createYoutubePlayer(). Tests pass.

The change
File: script.js
Behaviour: when the player is created, youtubePlayer = player; when destroyed/failed, youtubePlayer = null.
Verification
Ran: npm test
Result: all Cypress specs passed.
If you try again on the Samsung/FireTV with music enabled, this should reduce the “background YouTube still running” scenario, which is one of the more plausible routes to the crash page.